### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/LukeLarge/bicycle/security/code-scanning/1](https://github.com/LukeLarge/bicycle/security/code-scanning/1)

To fix this issue, the workflow should include an explicit `permissions` block set to the minimally required scope. Based on the workflow content, which only involves checking out code, installing dependencies, and running tests (with no writing to the repository, issues, or pull requests), the minimal required permission is `contents: read`. This setting provides the workflow GITHUB_TOKEN with only read access to repository contents. 

You can set the `permissions` block at the workflow (top/root) level or at the job level. Setting it at the root level will apply to all jobs (just `build` in this case). The best practice here is to add:

```yaml
permissions:
  contents: read
```

immediately after the `name:` block and before the `on:` key, or directly after (before `jobs:`). Region to change: edit `.github/workflows/go.yml` to add this `permissions` block at the workflow root. No additional methods, imports, or other definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
